### PR TITLE
Identity masking service.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 This is the back-end project for the customer portal.
 
-[![Build Status](https://jenkins.fintlabs.no/buildStatus/icon?job=FINTprosjektet/fint-kunde-portal/master)](https://jenkins.fintlabs.no/job/FINTprosjektet/job/fint-kunde-portal/job/master/)
+[![Build Status](https://jenkins.fintlabs.no/buildStatus/icon?job=FINTLabs/fint-kunde-portal-backend/master)](https://jenkins.fintlabs.no/job/FINTLabs/job/fint-kunde-portal-backend/job/master/)
 
-[Kunde portal](https://kunde.felleskomponent.no/)
+[Kundeportal](https://kunde.felleskomponent.no/)

--- a/src/main/java/no/fint/portal/ApplicationSecurity.java
+++ b/src/main/java/no/fint/portal/ApplicationSecurity.java
@@ -55,7 +55,7 @@ public class ApplicationSecurity extends WebSecurityConfigurerAdapter {
                 .authenticationProvider(preAuthenticatedAuthenticationProvider())
                 .authorizeRequests()
                 .anyRequest()
-                .authenticated()
+                .fullyAuthenticated()
                 .accessDecisionManager(accessDecisionManager());
     }
 }

--- a/src/main/java/no/fint/portal/customer/controller/ContactController.java
+++ b/src/main/java/no/fint/portal/customer/controller/ContactController.java
@@ -3,6 +3,7 @@ package no.fint.portal.customer.controller;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.extern.slf4j.Slf4j;
+import no.fint.portal.customer.service.IdentityMaskingService;
 import no.fint.portal.customer.service.PortalApiService;
 import no.fint.portal.exceptions.CreateEntityMismatchException;
 import no.fint.portal.exceptions.EntityFoundException;
@@ -41,6 +42,8 @@ public class ContactController {
     OrganisationService organisationService;
     @Autowired
     private ContactService contactService;
+    @Autowired
+    private IdentityMaskingService identityMaskingService;
 
     @ApiOperation("Create new contact")
     @RequestMapping(method = RequestMethod.POST,
@@ -86,7 +89,7 @@ public class ContactController {
     @ApiOperation("Get all contacts")
     @RequestMapping(method = RequestMethod.GET)
     public ResponseEntity getContacts() {
-        List<Contact> contacts = portalApiService.getContacts();
+        List<Contact> contacts = identityMaskingService.getMaskedContacts();
 
         if (contacts != null) {
             return ResponseEntity.ok().cacheControl(CacheControl.noStore()).body(contacts);

--- a/src/main/java/no/fint/portal/customer/service/IdentityMaskingService.java
+++ b/src/main/java/no/fint/portal/customer/service/IdentityMaskingService.java
@@ -6,13 +6,16 @@ import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
 import lombok.extern.slf4j.Slf4j;
 import no.fint.portal.model.contact.Contact;
+import no.fint.portal.model.contact.ContactObjectService;
+import no.fint.portal.model.organisation.Organisation;
+import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
-import javax.annotation.PostConstruct;
 import java.security.SecureRandom;
 import java.util.Base64;
 import java.util.List;
@@ -24,29 +27,42 @@ import java.util.stream.Collectors;
 @Slf4j
 public class IdentityMaskingService {
 
+    public static final String BULLETS = "\u2022\u2022\u2022\u2022\u2022";
+
     private ImmutableBiMap<String, String> identityMap;
     private final ReadWriteLock readWriteLock = new ReentrantReadWriteLock();
     private final SecureRandom random;
     private final PortalApiService portalApiService;
+    private final ContactObjectService contactObjectService;
 
     public IdentityMaskingService(
             RestTemplateBuilder builder,
             PortalApiService portalApiService,
-            @Value("${fint.drand.uri:https://drand.cloudflare.com}") String rootUri
-    ) {
+            @Value("${fint.drand.uri:https://api.drand.sh}") String rootUri,
+            ContactObjectService contactObjectService) {
         this.portalApiService = portalApiService;
-        final RestTemplate restTemplate = builder.rootUri(rootUri).build();
-        final String randomness = restTemplate.getForObject("/public/latest", JsonNode.class).get("randomness").asText();
-        log.info("Randomness seed: {}", randomness);
-        random = new SecureRandom(Base64.getDecoder().decode(randomness));
+        this.contactObjectService = contactObjectService;
+        random = getSecureRandom(builder, rootUri);
     }
 
-    @PostConstruct
-    @Scheduled(initialDelay = 1000, fixedDelay = 3600000)
+    private SecureRandom getSecureRandom(RestTemplateBuilder builder, String rootUri) {
+        try {
+            final RestTemplate restTemplate = builder.rootUri(rootUri).build();
+            final String randomness = restTemplate.getForObject("/public/latest", JsonNode.class).get("randomness").asText();
+            log.info("Randomness seed: {}", randomness);
+            return new SecureRandom(Base64.getDecoder().decode(randomness));
+        } catch (HttpClientErrorException e) {
+            log.warn("Unable to get a random seed: {}", e.getResponseBodyAsString());
+            return new SecureRandom();
+        }
+    }
+
+    @Scheduled(initialDelay = 10000, fixedDelay = 3600000)
     public void rotate() {
+        log.info("Rotating keys ...");
         try {
             readWriteLock.writeLock().lock();
-            final HashFunction hashFunction = Hashing.hmacSha256(random.generateSeed(256 / 8));
+            final HashFunction hashFunction = Hashing.hmacMd5(random.generateSeed(128 / 8));
             final ImmutableBiMap.Builder<String, String> builder = ImmutableBiMap.builder();
             final List<Contact> contacts = portalApiService.getContacts();
             if (contacts == null || contacts.isEmpty()) {
@@ -54,28 +70,55 @@ public class IdentityMaskingService {
                 return;
             }
 
-            contacts.stream().map(Contact::getNin)
-                    .forEach(nin -> builder.put(nin, hashFunction.hashUnencodedChars(nin).toString()));
+            contacts.forEach(contact -> {
+                String nin = contact.getNin();
+                final String hash = hashFunction.hashUnencodedChars(nin).toString();
+                builder.put(nin, hash);
+                builder.put(contact.getDn(), contactObjectService.getContactDn(hash));
+            });
 
             identityMap = builder.build();
         } finally {
             readWriteLock.writeLock().unlock();
         }
+        log.info("Map contains {} entries", identityMap.size());
     }
 
     public String mask(String nin) {
+        if (identityMap == null || identityMap.isEmpty()) {
+            rotate();
+        }
         return identityMap.get(nin);
+    }
+
+    public String unmask(String hash) {
+        if (identityMap == null || identityMap.isEmpty()) {
+            rotate();
+        }
+        return identityMap.inverse().get(hash);
     }
 
     public Contact mask(Contact input) {
         Contact output = new Contact();
+        output.setDn(mask(input.getDn()));
         output.setFirstName(input.getFirstName());
         output.setLastName(input.getLastName());
         output.setNin(mask(input.getNin()));
+        output.setMail(BULLETS);
+        output.setMobile(BULLETS);
+        return output;
+    }
+
+    public Organisation mask(Organisation input) {
+        Organisation output = new Organisation();
+        BeanUtils.copyProperties(input, output);
+        output.setLegalContact(mask(input.getLegalContact()));
+        output.setTechicalContacts(input.getTechicalContacts().stream().map(this::mask).collect(Collectors.toList()));
         return output;
     }
 
     public List<Contact> getMaskedContacts() {
         return portalApiService.getContacts().stream().map(this::mask).collect(Collectors.toList());
     }
+
 }

--- a/src/main/java/no/fint/portal/customer/service/IdentityMaskingService.java
+++ b/src/main/java/no/fint/portal/customer/service/IdentityMaskingService.java
@@ -57,7 +57,7 @@ public class IdentityMaskingService {
         }
     }
 
-    @Scheduled(initialDelay = 10000, fixedDelay = 3600000)
+    @Scheduled(cron = "${fint.identity.rotate.cron}")
     public void rotate() {
         log.info("Rotating keys ...");
         try {

--- a/src/main/java/no/fint/portal/customer/service/IdentityMaskingService.java
+++ b/src/main/java/no/fint/portal/customer/service/IdentityMaskingService.java
@@ -1,0 +1,81 @@
+package no.fint.portal.customer.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableBiMap;
+import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hashing;
+import lombok.extern.slf4j.Slf4j;
+import no.fint.portal.model.contact.Contact;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import javax.annotation.PostConstruct;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.List;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+public class IdentityMaskingService {
+
+    private ImmutableBiMap<String, String> identityMap;
+    private final ReadWriteLock readWriteLock = new ReentrantReadWriteLock();
+    private final SecureRandom random;
+    private final PortalApiService portalApiService;
+
+    public IdentityMaskingService(
+            RestTemplateBuilder builder,
+            PortalApiService portalApiService,
+            @Value("${fint.drand.uri:https://drand.cloudflare.com}") String rootUri
+    ) {
+        this.portalApiService = portalApiService;
+        final RestTemplate restTemplate = builder.rootUri(rootUri).build();
+        final String randomness = restTemplate.getForObject("/public/latest", JsonNode.class).get("randomness").asText();
+        log.info("Randomness seed: {}", randomness);
+        random = new SecureRandom(Base64.getDecoder().decode(randomness));
+    }
+
+    @PostConstruct
+    @Scheduled(initialDelay = 1000, fixedDelay = 3600000)
+    public void rotate() {
+        try {
+            readWriteLock.writeLock().lock();
+            final HashFunction hashFunction = Hashing.hmacSha256(random.generateSeed(256 / 8));
+            final ImmutableBiMap.Builder<String, String> builder = ImmutableBiMap.builder();
+            final List<Contact> contacts = portalApiService.getContacts();
+            if (contacts == null || contacts.isEmpty()) {
+                log.warn("Unable to retrieve contacts!");
+                return;
+            }
+
+            contacts.stream().map(Contact::getNin)
+                    .forEach(nin -> builder.put(nin, hashFunction.hashUnencodedChars(nin).toString()));
+
+            identityMap = builder.build();
+        } finally {
+            readWriteLock.writeLock().unlock();
+        }
+    }
+
+    public String mask(String nin) {
+        return identityMap.get(nin);
+    }
+
+    public Contact mask(Contact input) {
+        Contact output = new Contact();
+        output.setFirstName(input.getFirstName());
+        output.setLastName(input.getLastName());
+        output.setNin(mask(input.getNin()));
+        return output;
+    }
+
+    public List<Contact> getMaskedContacts() {
+        return portalApiService.getContacts().stream().map(this::mask).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/no/fint/portal/customer/service/PortalApiService.java
+++ b/src/main/java/no/fint/portal/customer/service/PortalApiService.java
@@ -199,7 +199,7 @@ public class PortalApiService {
     @Synchronized
     public List<Contact> getContacts() {
         List<Contact> contacts = contactService.getContacts();
-
+        if (contacts == null) throw new InvalidResourceException("null Contacts");
         if (contacts.size() == 0) return Collections.emptyList();
         if (contacts.get(0).getFirstName() == null) throw new InvalidResourceException("Invalid contact");
         return contacts;

--- a/src/main/java/no/fint/portal/security/SecureUrlAccessDecisionVoter.java
+++ b/src/main/java/no/fint/portal/security/SecureUrlAccessDecisionVoter.java
@@ -7,6 +7,7 @@ import org.springframework.security.access.AccessDecisionVoter;
 import org.springframework.security.access.ConfigAttribute;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.web.FilterInvocation;
 import org.springframework.stereotype.Service;
 
@@ -34,6 +35,10 @@ public class SecureUrlAccessDecisionVoter implements AccessDecisionVoter<FilterI
     @Override
     public int vote(Authentication authentication, FilterInvocation invocation, Collection<ConfigAttribute> attributes) {
         log.debug("VOTING FOR:\nAuthorities: {}\nURL: {}", authentication.getAuthorities(), invocation.getRequestUrl());
+        if (authentication.getAuthorities().isEmpty() || authentication.getAuthorities().contains(new SimpleGrantedAuthority("ROLE_ANONYMOUS"))) {
+            log.warn("{} has no granted authorities!", authentication.getPrincipal());
+            return ACCESS_DENIED;
+        }
         if (!StringUtils.startsWithAny(invocation.getRequestUrl(), securePaths)) {
             log.debug("Unsecured URL {}", invocation.getRequestUrl());
             return ACCESS_GRANTED;

--- a/src/main/java/no/fint/portal/security/UserService.java
+++ b/src/main/java/no/fint/portal/security/UserService.java
@@ -1,5 +1,6 @@
 package no.fint.portal.security;
 
+import no.fint.portal.customer.service.IdentityMaskingService;
 import no.fint.portal.customer.service.PortalApiService;
 import no.fint.portal.exceptions.EntityNotFoundException;
 import no.fint.portal.model.contact.Contact;
@@ -22,10 +23,12 @@ public class UserService implements UserDetailsService {
 
     private final PortalApiService portalApiService;
     private final OrganisationService organisationService;
+    private final IdentityMaskingService identityMaskingService;
 
-    public UserService(PortalApiService portalApiService, OrganisationService organisationService) {
+    public UserService(PortalApiService portalApiService, OrganisationService organisationService, IdentityMaskingService identityMaskingService) {
         this.portalApiService = portalApiService;
         this.organisationService = organisationService;
+        this.identityMaskingService = identityMaskingService;
     }
 
     @Override
@@ -36,7 +39,8 @@ public class UserService implements UserDetailsService {
         }
         try {
             final Contact contact = portalApiService.getContact(username);
-            return User.withDefaultPasswordEncoder()
+            return User.builder()
+                    .passwordEncoder(identityMaskingService::mask)
                     .username(contact.getMail())
                     .password(contact.getNin())
                     .authorities(Stream.concat(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,9 @@ springfox:
  version: '@version@'
 
 fint:
+  identity:
+    rotate:
+      cron: '0 0 0 * * *' # every midnight
   ldap:
     url: "${url}"
     user: "${user}"

--- a/src/test/java/no/fint/portal/customer/test/IntegrationTest.java
+++ b/src/test/java/no/fint/portal/customer/test/IntegrationTest.java
@@ -1,16 +1,22 @@
 package no.fint.portal.customer.test;
 
+import no.fint.portal.customer.service.IdentityMaskingService;
+import no.fint.portal.model.contact.Contact;
+import no.fint.portal.model.organisation.Organisation;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -21,6 +27,9 @@ public class IntegrationTest {
 
     @Autowired
     MockMvc mockMvc;
+
+    @MockBean
+    IdentityMaskingService identityMaskingService;
 
     String org = "testing";
     String component = "administrasjon_personal";
@@ -38,6 +47,7 @@ public class IntegrationTest {
 
     @Test
     public void assets() throws Exception {
+        when(identityMaskingService.mask(anyString())).thenAnswer(returnsFirstArg());
 
         mockMvc.perform(get("/api/assets/{org}/", org).header("x-nin", "12345678901")).andExpect(status().isOk());
         mockMvc.perform(post("/api/assets/{org}/", org).header("x-nin", "12345678901").content("{ \"assetId\": \"test\", \"description\": \"Test Norge AS\" }").contentType(MediaType.APPLICATION_JSON)).andExpect(status().is(201));
@@ -70,15 +80,23 @@ public class IntegrationTest {
 
     @Test
     public void contacts() throws Exception {
+        when(identityMaskingService.mask(anyString())).thenAnswer(returnsFirstArg());
+        when(identityMaskingService.unmask(anyString())).thenAnswer(returnsFirstArg());
+
         mockMvc.perform(get("/api/contacts").header("x-nin", "12345678901")).andExpect(status().is(200));
-        mockMvc.perform(get("/api/contacts/{contact}", contact1).header("x-nin", "12345678901")).andExpect(status().is(200)).andExpect(jsonPath("$.nin").value(containsString(contact1)));
+        // TODO Removed for privacy: mockMvc.perform(get("/api/contacts/{contact}", contact1).header("x-nin", "12345678901")).andExpect(status().is(200)).andExpect(jsonPath("$.nin").value(containsString(contact1)));
         mockMvc.perform(put("/api/contacts/{contact}", contact1).header("x-nin", "12345678901").content("{ \"nin\": \"12345678901\", \"firstName\": \"Tore Martin\", \"lastName\": \"Testesen\", \"mail\": \"test123@example.com\", \"mobile\": \"98765431\" }").contentType(MediaType.APPLICATION_JSON)).andExpect(status().is(200)).andExpect(jsonPath("$.mail").value(equalTo("test123@example.com")));
         mockMvc.perform(post("/api/contacts").header("x-nin", "12345678901").content("{ \"firstName\": \"John\", \"lastName\": \"Doe\", \"mail\": \"john.doe@example.com\", \"mobile\": \"1-800-555-1212\", \"nin\": \"00000000000\" }").contentType(MediaType.APPLICATION_JSON)).andExpect(status().is(201)).andExpect(jsonPath("$.nin").value(equalTo("00000000000")));
-        // TODO Removed for security mockMvc.perform(delete("/api/contacts/00000000000").header("x-nin", "12345678901")).andExpect(status().is(204));
+        // TODO Removed for security: mockMvc.perform(delete("/api/contacts/00000000000").header("x-nin", "12345678901")).andExpect(status().is(204));
     }
 
     @Test
     public void organisation() throws Exception {
+        when(identityMaskingService.mask(anyString())).thenAnswer(returnsFirstArg());
+        when(identityMaskingService.mask(any(Contact.class))).thenAnswer(returnsFirstArg());
+        when(identityMaskingService.mask(any(Organisation.class))).thenAnswer(returnsFirstArg());
+        when(identityMaskingService.unmask(anyString())).thenAnswer(returnsFirstArg());
+
         mockMvc.perform(get("/api/organisations/{org}/", org).header("x-nin", "12345678901")).andExpect(status().is(200));
         mockMvc.perform(put("/api/organisations/{org}/", org).header("x-nin", "12345678901").content("{ \"displayName\": \"Testing Unlimited\" }").contentType(MediaType.APPLICATION_JSON)).andExpect(status().is(200)).andExpect(jsonPath("$.displayName").value(containsString("Unlimited")));
         mockMvc.perform(put("/api/organisations/{org}/components/{component}", org, component).header("x-nin", "12345678901")).andExpect(status().is(204));
@@ -94,6 +112,9 @@ public class IntegrationTest {
 
     @Test
     public void security() throws Exception {
+        when(identityMaskingService.mask(anyString())).thenAnswer(returnsFirstArg());
+        when(identityMaskingService.unmask(anyString())).thenAnswer(returnsFirstArg());
+
         //mockMvc.perform(get("/api/organisations/{org}/", org)).andExpect(status().is(403));
         mockMvc.perform(put("/api/organisations/{org}/contacts/legal/{contact}", org, contact1).header("x-nin", "23456789012")).andExpect(status().is(403));
         mockMvc.perform(post("/api/adapters/{org}", org).header("x-nin", "23456789012").content("{ \"name\": \"testadapter\", \"note\": \"Test Adapter\", \"secret\": \"Open Sesame!\", \"shortDescription\": \"This is a Test Adapter\" }").contentType(MediaType.APPLICATION_JSON)).andExpect(status().is(403));


### PR DESCRIPTION
NIN, email and phone is now hidden from the client.

This is done by masking the NIN and DN of contacts using HMAC-MD5 with a random key.  This random key is rotated at midnight by default.

Seed for SecureRandom is fetched from DRAND for ultimate randomness.

Email and phone is presented as `•••••`, but can still be updated from the client in a write only fashion.