### PR TITLE
FL-368 Input sanitation in asset controller is moved to fint-portal-api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
 
     implementation 'com.google.guava:guava:30.1-jre'
 
-    implementation 'no.fint:fint-portal-api:3.12.0-rc-7'
+    implementation 'no.fintlabs:fint-portal-api:3.16.0'
     //implementation 'no.fint:fint-portal-api:0-SNAPSHOT'
     implementation 'no.fint:fint-audit-api:1.2.2'
 


### PR DESCRIPTION
Input sanitation in asset controller are moved to fint-portal-api by version 3.16.0
But this repo did not use the previous version. It used an older version 3.12.0-rc-7.
How do we test and verify booth mine but also these other changes?