### PR TITLE
Return 400 instead of 500 for missing or unknown x-nin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,8 @@ plugins {
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
     id 'groovy'
+    id 'org.jetbrains.kotlin.jvm' version '1.9.22'
+    id 'org.jetbrains.kotlin.plugin.spring' version '1.9.22'
 }
 
 group = 'no.fint'
@@ -10,6 +12,20 @@ version = '0.0.1-SNAPSHOT'
 
 java{
     sourceCompatibility = '17'
+}
+
+compileKotlin {
+    kotlinOptions {
+        freeCompilerArgs = ['-Xjsr305=strict']
+        jvmTarget = '17'
+    }
+}
+
+compileTestKotlin {
+    kotlinOptions {
+        freeCompilerArgs = ['-Xjsr305=strict']
+        jvmTarget = '17'
+    }
 }
 
 jar{
@@ -31,6 +47,9 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.jetbrains.kotlin:kotlin-reflect'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-cache'

--- a/src/main/java/no/fint/portal/ApplicationSecurity.java
+++ b/src/main/java/no/fint/portal/ApplicationSecurity.java
@@ -2,6 +2,7 @@ package no.fint.portal;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import no.fint.portal.security.MissingCredentialsAuthenticationEntryPoint;
 import no.fint.portal.security.SecureUrlAccessDecisionVoter;
 import no.fint.portal.security.UserService;
 import org.springframework.context.annotation.Bean;
@@ -11,7 +12,6 @@ import org.springframework.security.access.vote.UnanimousBased;
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
-import org.springframework.security.config.annotation.web.configurers.oauth2.server.resource.OAuth2ResourceServerConfigurer;
 import org.springframework.security.core.userdetails.UserDetailsByNameServiceWrapper;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationProvider;
@@ -26,11 +26,13 @@ public class ApplicationSecurity {
 
     private final SecureUrlAccessDecisionVoter voter;
     private final UserService userService;
+    private final MissingCredentialsAuthenticationEntryPoint authenticationEntryPoint;
 
     @Bean
     public RequestHeaderAuthenticationFilter requestHeaderAuthenticationFilter(PreAuthenticatedAuthenticationProvider preAuthenticatedAuthenticationProvider) {
         RequestHeaderAuthenticationFilter requestHeaderAuthenticationFilter = new RequestHeaderAuthenticationFilter();
         requestHeaderAuthenticationFilter.setPrincipalRequestHeader("x-nin");
+        requestHeaderAuthenticationFilter.setExceptionIfHeaderMissing(false);
         requestHeaderAuthenticationFilter.setAuthenticationManager(new ProviderManager(Collections.singletonList(preAuthenticatedAuthenticationProvider)));
         return requestHeaderAuthenticationFilter;
     }
@@ -55,6 +57,7 @@ public class ApplicationSecurity {
                 .sessionManagement(AbstractHttpConfigurer::disable)
                 .addFilter(requestHeaderAuthenticationFilter(preAuthenticatedAuthenticationProvider()))
                 .authenticationProvider(preAuthenticatedAuthenticationProvider())
+                .exceptionHandling(e -> e.authenticationEntryPoint(authenticationEntryPoint))
                 .authorizeRequests(registry -> {
                     registry.anyRequest().fullyAuthenticated();
                     registry.accessDecisionManager(accessDecisionManager());

--- a/src/main/java/no/fint/portal/customer/controller/GlobalExceptionHandler.java
+++ b/src/main/java/no/fint/portal/customer/controller/GlobalExceptionHandler.java
@@ -4,7 +4,6 @@ import lombok.extern.slf4j.Slf4j;
 import no.fint.portal.model.ErrorResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.web.authentication.preauth.PreAuthenticatedCredentialsNotFoundException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.WebRequest;
@@ -15,12 +14,6 @@ import javax.servlet.http.HttpServletRequest;
 @Slf4j
 @ControllerAdvice
 public class GlobalExceptionHandler {
-
-    @ExceptionHandler(PreAuthenticatedCredentialsNotFoundException.class)
-    public ResponseEntity<ErrorResponse> handlePreAuthenticatedCredentialsNotFoundException(PreAuthenticatedCredentialsNotFoundException ex, HttpServletRequest httpRequest) {
-        log.error("Missing pre-authenticated credentials: {} on request to: {}", ex.getMessage(), httpRequest.getRequestURL());
-        return new ResponseEntity<>(new ErrorResponse("Authentication credentials were not found."), HttpStatus.UNAUTHORIZED);
-    }
 
     @ExceptionHandler(NoHandlerFoundException.class)
     public ResponseEntity<ErrorResponse> handleNoHandlerFoundException(NoHandlerFoundException ex) {

--- a/src/main/kotlin/no/fint/portal/security/MissingCredentialsAuthenticationEntryPoint.kt
+++ b/src/main/kotlin/no/fint/portal/security/MissingCredentialsAuthenticationEntryPoint.kt
@@ -1,0 +1,42 @@
+package no.fint.portal.security
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import no.fint.portal.model.ErrorResponse
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.stereotype.Component
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+@Component
+class MissingCredentialsAuthenticationEntryPoint(
+    private val objectMapper: ObjectMapper,
+) : AuthenticationEntryPoint {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    override fun commence(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        authException: AuthenticationException,
+    ) {
+        val message = if (request.getHeader(HEADER) == null) {
+            "Missing required request header: $HEADER"
+        } else {
+            "Invalid or unknown $HEADER"
+        }
+
+        log.debug("Rejecting {} {} — {}", request.method, request.requestURI, message)
+
+        response.status = HttpStatus.BAD_REQUEST.value()
+        response.contentType = MediaType.APPLICATION_JSON_VALUE
+        objectMapper.writeValue(response.writer, ErrorResponse(message))
+    }
+
+    companion object {
+        private const val HEADER = "x-nin"
+    }
+}

--- a/src/test/java/no/fint/portal/customer/test/IntegrationTest.java
+++ b/src/test/java/no/fint/portal/customer/test/IntegrationTest.java
@@ -177,6 +177,27 @@ public class IntegrationTest {
                 .andExpect(status().is(204));
     }
 
+    // `SecureUrlAccessDecisionVoter` only enforces auth on URLs starting with role URIs
+    // (e.g. /api/organisations/). Paths outside that set stay publicly reachable.
+    @Test
+    public void missingXNinOnSecuredPathReturns400() throws Exception {
+        mockMvc.perform(get("/api/organisations/{org}/", org))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(containsString("x-nin")));
+    }
+
+    @Test
+    public void unknownXNinOnSecuredPathReturns400() throws Exception {
+        mockMvc.perform(get("/api/organisations/{org}/", org).header("x-nin", "00000000000"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void missingXNinOnUnsecuredPathStillServed() throws Exception {
+        mockMvc.perform(get("/components"))
+                .andExpect(status().isOk());
+    }
+
     @Test
     public void access() throws Exception {
         when(identityMaskingService.mask(anyString())).thenAnswer(returnsFirstArg());

--- a/src/test/kotlin/no/fint/portal/security/MissingCredentialsAuthenticationEntryPointTest.kt
+++ b/src/test/kotlin/no/fint/portal/security/MissingCredentialsAuthenticationEntryPointTest.kt
@@ -1,0 +1,42 @@
+package no.fint.portal.security
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.security.authentication.InsufficientAuthenticationException
+
+class MissingCredentialsAuthenticationEntryPointTest {
+
+    private val entryPoint = MissingCredentialsAuthenticationEntryPoint(ObjectMapper())
+
+    @Test
+    fun `writes 400 with missing-header message when x-nin is absent`() {
+        val request = MockHttpServletRequest("GET", "/organisations/foo")
+        val response = MockHttpServletResponse()
+
+        entryPoint.commence(request, response, InsufficientAuthenticationException("no auth"))
+
+        assertThat(response.status).isEqualTo(HttpStatus.BAD_REQUEST.value())
+        assertThat(response.contentType).isEqualTo(MediaType.APPLICATION_JSON_VALUE)
+        assertThat(response.contentAsString)
+            .contains("Missing required request header")
+            .contains("x-nin")
+    }
+
+    @Test
+    fun `writes 400 with invalid-header message when x-nin is present but unknown`() {
+        val request = MockHttpServletRequest("GET", "/organisations/foo").apply {
+            addHeader("x-nin", "99999999999")
+        }
+        val response = MockHttpServletResponse()
+
+        entryPoint.commence(request, response, InsufficientAuthenticationException("unknown user"))
+
+        assertThat(response.status).isEqualTo(HttpStatus.BAD_REQUEST.value())
+        assertThat(response.contentAsString).contains("Invalid or unknown x-nin")
+    }
+}


### PR DESCRIPTION
## Summary

- Missing or unknown `x-nin` now returns **400 Bad Request** with a JSON `ErrorResponse` instead of a 500 + stack trace.
- Swaps Spring Security's `RequestHeaderAuthenticationFilter` default throw for a custom `AuthenticationEntryPoint` that writes the 400 response.
- Introduces Kotlin to the project (plugins + stdlib), starting with the new entry point and its unit test.
- Removes a dead `@ControllerAdvice` handler that could never fire (filter-level exceptions bypass `@ControllerAdvice`).

## Behavior

- **Secured paths** (any URL starting with a role URI in `application.yml`: `/api/organisations/`, `/api/clients/`, `/api/adapters/`, `/api/assets/`, `/api/tests/`, `/api/events/`, `/api/components/organisation/`): missing/unknown `x-nin` → **400**.
- **Unsecured paths** (e.g. `/api/components`, `/api/me`, `/api/contacts`): unchanged — these were already reachable without `x-nin` per `SecureUrlAccessDecisionVoter`. Previously they 5xx'd on missing header because the filter threw before the voter ran; they now respond normally.

## Tests

- `IntegrationTest`: new cases for missing and unknown `x-nin` on a secured path (expect 400), plus a regression test that an unsecured path still responds 200 without `x-nin`.
- `MissingCredentialsAuthenticationEntryPointTest` (Kotlin): unit test for the entry point — verifies 400, JSON content type, and message wording for both missing-header and invalid-header cases.