### PR TITLE
fix: exclude managed clients from model version metrics

### DIFF
--- a/src/main/kotlin/no/fint/portal/customer/service/ClientMetricService.kt
+++ b/src/main/kotlin/no/fint/portal/customer/service/ClientMetricService.kt
@@ -32,7 +32,7 @@ class ClientMetricService(
     fun refreshCache() {
         try {
             val clientsByOrg = organisationService.organisations.associate { org ->
-                OrgName(org.name) to clientService.getClients(org.name)
+                OrgName(org.name) to clientService.getClients(org.name).filterNot { it.isManaged }
             }
 
             val newStats = ClientModelVersionStats.from(clientsByOrg)

--- a/src/test/kotlin/no/fint/portal/customer/service/ClientMetricServiceTest.kt
+++ b/src/test/kotlin/no/fint/portal/customer/service/ClientMetricServiceTest.kt
@@ -92,6 +92,19 @@ class ClientMetricServiceTest {
     }
 
     @Test
+    fun `refreshCache excludes managed clients`() {
+        setupOrgs("org1" to listOf(
+            createClient(ModelVersion.V4, managed = false),
+            createClient(ModelVersion.V4, managed = true),
+            createClient(ModelVersion.V4, managed = true)
+        ))
+
+        service.refreshCache()
+
+        assertEquals(1L, service.getStats().countsByOrg()[OrgName("org1")]!![ModelVersion.V4])
+    }
+
+    @Test
     fun `getStats returns empty stats before first refresh`() {
         assertTrue(service.getStats().countsByOrg().isEmpty())
     }
@@ -116,8 +129,9 @@ class ClientMetricServiceTest {
         }
     }
 
-    private fun createClient(version: ModelVersion?) = Client().apply {
+    private fun createClient(version: ModelVersion?, managed: Boolean = false) = Client().apply {
         this.modelVersion = version
+        this.isManaged = managed
     }
 
     private fun findGauge(org: String, version: String) =


### PR DESCRIPTION
## Summary
- `ClientMetricService.refreshCache()` now filters out managed clients (`Client.isManaged == true`) before grouping/counting per organisation.
- Managed clients were being counted alongside customer-owned clients in the `fint.clients.model.version` gauge, inflating the numbers we surface to organisations.
- Added a unit test in `ClientMetricServiceTest` that verifies managed clients are excluded from the cached stats.

No changes to the REST endpoint shape or to the gauge tag set — only the underlying client list is filtered.