### PR TITLE
fix: only count clients with an utdanning component in V3/V4 stats

### DIFF
--- a/src/main/kotlin/no/fint/portal/customer/model/ClientModelVersionStats.kt
+++ b/src/main/kotlin/no/fint/portal/customer/model/ClientModelVersionStats.kt
@@ -16,11 +16,15 @@ class ClientModelVersionStats(
 
         fun from(clientsByOrg: Map<OrgName, List<Client>>): ClientModelVersionStats {
             val countsByOrg = clientsByOrg.mapValues { (_, clients) ->
-                clients.groupingBy { it.modelVersion ?: ModelVersion.V3 }
+                clients.filter { it.hasUtdanningComponent() }
+                    .groupingBy { it.modelVersion ?: ModelVersion.V3 }
                     .eachCount()
                     .mapValues { it.value.toLong() }
             }
             return ClientModelVersionStats(countsByOrg)
         }
+
+        private fun Client.hasUtdanningComponent(): Boolean =
+            components?.any { it.contains("utdanning", ignoreCase = true) } == true
     }
 }

--- a/src/test/kotlin/no/fint/portal/customer/controller/ClientMetricControllerTest.kt
+++ b/src/test/kotlin/no/fint/portal/customer/controller/ClientMetricControllerTest.kt
@@ -60,5 +60,6 @@ class ClientMetricControllerTest {
 
     private fun clientWith(version: ModelVersion) = no.fint.portal.model.client.Client().apply {
         modelVersion = version
+        addComponent("utdanning_elev")
     }
 }

--- a/src/test/kotlin/no/fint/portal/customer/model/ClientModelVersionStatsTest.kt
+++ b/src/test/kotlin/no/fint/portal/customer/model/ClientModelVersionStatsTest.kt
@@ -56,6 +56,23 @@ class ClientModelVersionStatsTest {
     }
 
     @Test
+    fun `from only counts clients with at least one utdanning component`() {
+        val stats = ClientModelVersionStats.from(
+            mapOf(org1 to listOf(
+                createClient(ModelVersion.V3, listOf("utdanning_elev")),
+                createClient(ModelVersion.V4, listOf("administrasjon_personal")),
+                createClient(ModelVersion.V4, listOf("arkiv_noark", "utdanning_vurdering")),
+                createClient(ModelVersion.V4, emptyList()),
+                createClient(ModelVersion.V4, null)
+            ))
+        )
+
+        val counts = stats.countsByOrg()[org1]!!
+        assertEquals(1L, counts[ModelVersion.V3])
+        assertEquals(1L, counts[ModelVersion.V4])
+    }
+
+    @Test
     fun `from handles empty client list`() {
         val stats = ClientModelVersionStats.from(mapOf(emptyOrg to emptyList()))
 
@@ -87,7 +104,11 @@ class ClientModelVersionStatsTest {
         assertTrue(stats.countsFor(OrgName("nonexistent")).isEmpty())
     }
 
-    private fun createClient(version: ModelVersion?) = Client().apply {
+    private fun createClient(
+        version: ModelVersion?,
+        components: List<String>? = listOf("utdanning_elev")
+    ) = Client().apply {
         this.modelVersion = version
+        if (components != null) components.forEach { addComponent(it) }
     }
 }

--- a/src/test/kotlin/no/fint/portal/customer/service/ClientMetricServiceTest.kt
+++ b/src/test/kotlin/no/fint/portal/customer/service/ClientMetricServiceTest.kt
@@ -105,6 +105,19 @@ class ClientMetricServiceTest {
     }
 
     @Test
+    fun `refreshCache only counts clients with an utdanning component`() {
+        setupOrgs("org1" to listOf(
+            createClient(ModelVersion.V4, components = listOf("utdanning_elev")),
+            createClient(ModelVersion.V4, components = listOf("administrasjon_personal")),
+            createClient(ModelVersion.V4, components = emptyList())
+        ))
+
+        service.refreshCache()
+
+        assertEquals(1L, service.getStats().countsByOrg()[OrgName("org1")]!![ModelVersion.V4])
+    }
+
+    @Test
     fun `getStats returns empty stats before first refresh`() {
         assertTrue(service.getStats().countsByOrg().isEmpty())
     }
@@ -129,9 +142,14 @@ class ClientMetricServiceTest {
         }
     }
 
-    private fun createClient(version: ModelVersion?, managed: Boolean = false) = Client().apply {
+    private fun createClient(
+        version: ModelVersion?,
+        managed: Boolean = false,
+        components: List<String> = listOf("utdanning_elev")
+    ) = Client().apply {
         this.modelVersion = version
         this.isManaged = managed
+        components.forEach { addComponent(it) }
     }
 
     private fun findGauge(org: String, version: String) =


### PR DESCRIPTION
## Summary

The V3/V4 client model version metric is only meaningful for the utdanning domain. Clients that don't have at least one component whose name contains \"utdanning\" are now filtered out before grouping by model version, both in the cached stats and the exposed Micrometer gauges.

## Changes

- \`ClientModelVersionStats.from\` filters clients by \`hasUtdanningComponent()\` (case-insensitive substring match on \`components\`) before counting.
- Test helpers in \`ClientModelVersionStatsTest\`, \`ClientMetricServiceTest\`, and \`ClientMetricControllerTest\` now attach an \`utdanning_elev\` component by default; new cases cover non-utdanning and component-less clients being filtered out.